### PR TITLE
Add Express auth server with RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Auth Server
+
+Simple Express authentication server with role-based access control using an in-memory user store. Designed for testing and demonstration purposes.
+
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+## Running the Server
+
+```bash
+npm start
+```
+
+## Running Tests
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "auth-server",
+  "version": "1.0.0",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+const app = express();
+app.use(express.json());
+
+// In-memory users store
+const users = [
+  { id: 1, username: 'admin', password: 'password', role: 'admin' },
+  { id: 2, username: 'user', password: 'password', role: 'user' }
+];
+
+const JWT_SECRET = 'secret';
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided' });
+
+  jwt.verify(token, JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token' });
+    req.user = user;
+    next();
+  });
+}
+
+function authorizeRoles(...roles) {
+  return (req, res, next) => {
+    if (!roles.includes(req.user.role)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    next();
+  };
+}
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username && u.password === password);
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+
+  const token = jwt.sign({ id: user.id, username: user.username, role: user.role }, JWT_SECRET, { expiresIn: '1h' });
+  res.json({ token });
+});
+
+app.get('/profile', authenticateToken, (req, res) => {
+  res.json({ id: req.user.id, username: req.user.username, role: req.user.role });
+});
+
+app.get('/admin', authenticateToken, authorizeRoles('admin'), (req, res) => {
+  res.json({ message: 'Welcome Admin!' });
+});
+
+const port = process.env.PORT || 3000;
+if (require.main === module) {
+  app.listen(port, () => console.log(`Server running on port ${port}`));
+}
+
+module.exports = { app, users };

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,47 @@
+const request = require('supertest');
+const { app } = require('../src/server');
+
+describe('Authentication and RBAC', () => {
+  it('logs in a user and returns a token', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'admin', password: 'password' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('allows access to profile with valid token', async () => {
+    const login = await request(app)
+      .post('/login')
+      .send({ username: 'user', password: 'password' });
+    const token = login.body.token;
+    const res = await request(app)
+      .get('/profile')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.username).toBe('user');
+  });
+
+  it('denies access to admin route for non-admin user', async () => {
+    const login = await request(app)
+      .post('/login')
+      .send({ username: 'user', password: 'password' });
+    const token = login.body.token;
+    const res = await request(app)
+      .get('/admin')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('allows admin user to access admin route', async () => {
+    const login = await request(app)
+      .post('/login')
+      .send({ username: 'admin', password: 'password' });
+    const token = login.body.token;
+    const res = await request(app)
+      .get('/admin')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe('Welcome Admin!');
+  });
+});


### PR DESCRIPTION
## Summary
- implement Express server with in-memory users, JWT auth, and role-based access control
- add Jest and Supertest tests for login, profile, and admin endpoints
- document setup and usage in README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a6d708d0832cb0b1f4cce13e297d